### PR TITLE
fix: allow null for maxTokens in model route upsert schema

### DIFF
--- a/server/src/routes/llm.ts
+++ b/server/src/routes/llm.ts
@@ -79,7 +79,7 @@ const modelRouteUpsertSchema = z.object({
   provider: z.string().trim().min(1),
   model: z.string().trim().min(1),
   temperature: z.number().min(0).max(2).optional(),
-  maxTokens: z.number().int().min(64).max(16384).optional(),
+  maxTokens: z.union([z.number().int().min(64).max(16384), z.null()]).optional(),
 });
 
 router.put(


### PR DESCRIPTION
## 问题描述

在模型路由管理台页面保存配置时，如果'最大输出长度'字段留空，前端会传递 null 值，但后端 Zod schema 只接受 number | undefined，导致校验失败：

```
Invalid input: expected number, received null
```

## 复现步骤

1. 进入 /settings/model-routes
2. 选择一个任务（如'主笔作家'）
3. 配置服务商和模型
4. 将'最大输出长度'留空
5. 点击'保存路由'
6. 报错：请求参数校验失败

## 修复方案

将 Zod schema 从：
```typescript
maxTokens: z.number().int().min(64).max(16384).optional()
```

修改为：
```typescript
maxTokens: z.union([z.number().int().min(64).max(16384), z.null()]).optional()
```

使其能够接受 number、null 或 undefined 三种类型。

## 测试

- [x] 留空 maxTokens 时可以成功保存
- [x] 填写有效数值时可以成功保存
- [x] 保存后模型路由配置正确加载