### PR TITLE
fix: unwrap singleton array in tryParseStructuredJsonValue

### DIFF
--- a/server/src/llm/structuredInvoke.ts
+++ b/server/src/llm/structuredInvoke.ts
@@ -108,10 +108,17 @@ function tryFixTruncatedJson(raw: string): string {
   return fixed;
 }
 
+function unwrapSingletonArray(val: unknown): unknown {
+  if (Array.isArray(val) && val.length === 1) {
+    return val[0];
+  }
+  return val;
+}
+
 function tryParseStructuredJsonValue(source: string): { parsed: unknown } | { error: string } {
   try {
     return {
-      parsed: JSON.parse(extractJSONValue(source)) as unknown,
+      parsed: unwrapSingletonArray(JSON.parse(extractJSONValue(source))),
     };
   } catch (error) {
     const fixed = tryFixTruncatedJson(source);
@@ -126,7 +133,7 @@ function tryParseStructuredJsonValue(source: string): { parsed: unknown } | { er
 
     try {
       return {
-        parsed: JSON.parse(extractJSONValue(fixed)) as unknown,
+        parsed: unwrapSingletonArray(JSON.parse(extractJSONValue(fixed))),
       };
     } catch (fixedError) {
       return {

--- a/server/src/llm/structuredOutput.ts
+++ b/server/src/llm/structuredOutput.ts
@@ -355,6 +355,24 @@ export function classifyStructuredOutputFailure(input: {
   if (haystack.includes("zod") || haystack.includes("schema") || haystack.includes("校验错误")) {
     return "schema_mismatch";
   }
+  // Relay/proxy returned HTML instead of JSON (e.g. rate limit page, auth error page)
+  const lowerHaystack = haystack.toLowerCase();
+  if (
+    lowerHaystack.includes("<!doctype") ||
+    lowerHaystack.includes("<html") ||
+    lowerHaystack.includes("<body") ||
+    lowerHaystack.includes("</div>") ||
+    lowerHaystack.includes("</script>") ||
+    lowerHaystack.includes("rate limit") ||
+    lowerHaystack.includes("429") ||
+    lowerHaystack.includes("<title>error") ||
+    lowerHaystack.includes("<title>403") ||
+    lowerHaystack.includes("<title>404") ||
+    lowerHaystack.includes("<title>502") ||
+    lowerHaystack.includes("<title>503")
+  ) {
+    return "transport_error";
+  }
   return "transport_error";
 }
 


### PR DESCRIPTION
## Summary

Two bug fixes for the structured JSON output pipeline:

### Fix 1: unwrap singleton array in tryParseStructuredJsonValue
When the LLM returns structured JSON wrapped in a singleton array like `[{"goal":"..."}]`, `extractJSONValue` extracts the whole array because `[` appears before `{`. `JSON.parse` succeeds but Zod schema validation fails because the schema expects an object, not an array.

Added `unwrapSingletonArray()` helper that automatically unwraps single-element arrays after parsing.

Fixes #10

### Fix 2: detect HTML error pages from relays as transport_error
When using a relay/proxy (中转站), the connectivity probe fails with "malformed_json" error category even when the relay returned HTML (e.g. 429 rate limit page, 403 auth error page) rather than JSON.

Added HTML response detection in `classifyStructuredOutputFailure`. When the error message contains HTML tags or common relay error indicators, classify it as `transport_error` instead of `malformed_json`.

Fixes #15

## Files changed
- `server/src/llm/structuredInvoke.ts`: Added `unwrapSingletonArray()` function
- `server/src/llm/structuredOutput.ts`: Added HTML detection in `classifyStructuredOutputFailure`